### PR TITLE
feat: Add vercel.json to handle SPA routing

### DIFF
--- a/protasked-react-app/vercel.json
+++ b/protasked-react-app/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Adds a `vercel.json` configuration file to the `protasked-react-app` directory.

This file includes a rewrite rule to direct all traffic to `index.html`, which is necessary for single-page applications (SPAs) to function correctly on Vercel. This change resolves the 404 "NOT_FOUND" error that occurs when accessing the deployed application.